### PR TITLE
Atualiza domínio da API do frontend

### DIFF
--- a/frontend/src/environment/environment.prod.ts
+++ b/frontend/src/environment/environment.prod.ts
@@ -1,5 +1,5 @@
 // src/environments/environment.prod.ts
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:3000/api'
+  apiUrl: 'https://ap1.frigoias.com.br/api'
 };

--- a/frontend/src/environment/environment.ts
+++ b/frontend/src/environment/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:3000/api'
+  apiUrl: 'https://ap1.frigoias.com.br/api'
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:3000/api'
+  apiUrl: 'https://ap1.frigoias.com.br/api'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:3000/api'
+  apiUrl: 'https://ap1.frigoias.com.br/api'
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "target": "es2015",
+    "skipLibCheck": true,
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
## Summary
- configure `apiUrl` nos ambientes de produção e desenvolvimento
- ignorar verificações de tipos de bibliotecas para compilar no Node atual

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505970ac68832981c65ec6a35de8b3