### PR TITLE
Fix Passenger startup path

### DIFF
--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,5 +1,5 @@
 <IfModule mod_passenger.c>
   PassengerEnabled on
   PassengerAppRoot /home1/frigoi12/public_html/auditoria/backend
-  PassengerStartupFile src/index.js
+  PassengerStartupFile index.js
 </IfModule>


### PR DESCRIPTION
## Summary
- point PassengerStartupFile directly at index.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685058c2a734832982bb5b7e2d13d498