### PR TITLE
Add env-based CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ npm install
 npm run dev  # ou npm start
 ```
 
+Para liberar o acesso via CORS, crie um arquivo `.env` em `backend` definindo a
+variável `ALLOWED_ORIGINS` com a lista de domínios permitidos. Separe-os por
+vírgulas:
+
+```
+ALLOWED_ORIGINS=https://frigoias.com.br,https://ap1.frigoias.com.br
+```
+
+Inclua o domínio usado no HostGator (`https://ap1.frigoias.com.br`).
+
 ### Frontend
 ```bash
 cd frontend

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,13 +6,14 @@
 
     const app = express();
 
-    // Habilita CORS apenas para seus domínios HTTPS
+    // Habilita CORS lendo os domínios permitidos de variáveis de ambiente
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+        .split(',')
+        .map(o => o.trim())
+        .filter(Boolean);
+
     app.use(cors({
         origin: function (origin, callback) {
-            const allowedOrigins = [
-                'https://frigoias.com.br',
-                'https://ap1.frigoias.com.br'
-            ];
             if (!origin || allowedOrigins.includes(origin)) {
                 callback(null, true);
             } else {


### PR DESCRIPTION
## Summary
- read allowed CORS origins from environment variables in `backend/index.js`
- update README with instructions on setting `ALLOWED_ORIGINS`

## Testing
- `npm test` *(fails: missing script)*
- `cd backend && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685058bdd83c8329b68cd6ff2d0351c4