### PR TITLE
Fix SSL configuration for PostgreSQL connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ npx ng serve
 ```
 
 Abra http://localhost:4200 e a aplicação estará funcionando, consumindo a API em http://localhost:3000/api.
+
+## Configuração do banco de dados
+
+A aplicação backend utiliza variáveis de ambiente para configurar a conexão
+com o PostgreSQL. Você pode informar os dados individualmente (`DB_USER`,
+`DB_HOST`, `DB_NAME`, `DB_PASS`, `DB_PORT`) ou utilizar a variável
+`DATABASE_URL` contendo a string de conexão completa.
+
+Quando a aplicação roda em produção (`NODE_ENV=production`), o SSL será
+ativado automaticamente. Para forçar ou desativar esse comportamento, defina a
+variável `SSL` como `true` ou `false`.


### PR DESCRIPTION
## Summary
- make PostgreSQL SSL optional via `SSL` env var

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68505b52904083298fa7c1ffefe0fb4e