### PR TITLE
Enable LAN server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,25 @@ npx ng serve
 ```
 
 Abra http://localhost:4200 e a aplicação estará funcionando, consumindo a API em http://localhost:3000/api.
+
+## Servidor Windows em Rede Local
+
+Para disponibilizar a aplicação em um servidor Windows acessível pela LAN:
+
+1. Configure o arquivo `.env` do backend seguindo o modelo em `backend/.env.example`,
+   usando `DB_HOST=SRVAP02FG.frigoias.corp`, `DB_PORT=5432` e `DB_PASS=root`.
+2. Altere as configurações do PostgreSQL para aceitar conexões remotas (`postgresql.conf` com `listen_addresses='*'` e `pg_hba.conf` liberando a rede interna).
+3. Libere no firewall as portas **5432** (PostgreSQL) e **3000** (Node.js).
+4. Inicie a API executando no diretório `backend`:
+   ```bash
+   npm install
+   npm start
+   ```
+   O servidor escutará em todas as interfaces (`0.0.0.0`).
+5. No frontend, ajuste `environment.ts` para apontar para `http://192.168.0.100:3000/api` (já configurado neste repositório). Para gerar os arquivos estáticos e servi-los na porta 80:
+   ```bash
+   npm run build
+   npx serve -s dist/auditoria -l 80
+   ```
+   Assim a aplicação Angular ficará acessível em `http://192.168.0.100`.
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=SRVAP02FG.frigoias.corp
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=root
+DB_NAME=controle_industrial
+PORT=3000

--- a/backend/index.js
+++ b/backend/index.js
@@ -401,7 +401,8 @@
     });
 
     // Inicia o servidor na porta alocada pelo cPanel
-    const PORT = parseInt(process.env.PORT, 10) || 3000;
-    app.listen(PORT, () => {
-        console.log(`Servidor rodando na porta ${PORT}`);
-    });
+const PORT = parseInt(process.env.PORT, 10) || 3000;
+// Escuta em todas as interfaces para acesso pela rede local
+app.listen(PORT, '0.0.0.0', () => {
+    console.log(`Servidor rodando na porta ${PORT}`);
+});

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:3000/api'
+  // IP do servidor Windows na rede interna
+  apiUrl: 'http://192.168.0.100:3000/api'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:3000/api'
+  // IP do servidor Windows na rede interna
+  apiUrl: 'http://192.168.0.100:3000/api'
 };

--- a/server-config.md
+++ b/server-config.md
@@ -1,0 +1,35 @@
+# Configuração do Servidor Windows
+
+Este arquivo resume os passos necessários para hospedar a aplicação `auditoria_industrial` em um servidor Windows acessível pela rede interna.
+
+## PostgreSQL
+1. Edite `postgresql.conf` e defina:
+   ```
+   listen_addresses = '*'
+   ```
+2. No `pg_hba.conf`, permita conexões da rede local. Exemplo:
+   ```
+   host    all             all             192.168.0.0/24        md5
+   ```
+3. Reinicie o serviço do PostgreSQL após as alterações.
+
+## Firewall
+Abra as seguintes portas no Windows Firewall:
+- **5432**: para conexões ao PostgreSQL
+- **3000**: para a API Node.js
+
+## Execução da API
+Na pasta `backend` execute:
+```bash
+npm install
+npm start
+```
+O servidor será iniciado em `0.0.0.0:3000`.
+
+## Servindo o Frontend
+Na pasta `frontend`:
+```bash
+npm run build
+npx serve -s dist/auditoria -l 80
+```
+A aplicação ficará disponível em `http://<ip-do-servidor>`.


### PR DESCRIPTION
## Summary
- expose the API on all interfaces
- configure environments to use the LAN IP
- add `.env.example` template
- document Windows server setup and configuration
- update example configuration details

## Testing
- `npm test` in backend *(fails: Missing script)*
- `npm test` in frontend *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685186855e94832f81958b8b7f55ce77